### PR TITLE
add plausibility checks for input to avoid using 3D inclusionType in 2D model

### DIFF
--- a/gmshModel/Model/RandomInclusionRVE.py
+++ b/gmshModel/Model/RandomInclusionRVE.py
@@ -133,7 +133,9 @@ class RandomInclusionRVE(InclusionRVE):
         # plausibility checks for input variables
         if inclusionSets is None:
             raise TypeError("Variable \"inclusionSets\" not set! For RVEs with random inclusion distributions, the inclusionSets must be defined. Check your input data.")
-
+        if inclusionType != "Circle" and size[2] == 0.0: 
+            raise TypeError("2D model but with 3D inclusion type! Check your input data.")
+            
         # update inclusion sets to start placement with biggest inclusions
         inclusionSets=np.atleast_2d(inclusionSets)                              # type conversion for inclusionSets to be matrix-like
         inclusionSets=inclusionSets[inclusionSets[:,0].argsort(axis=0)[::-1]]   # sort inclusionSets (descending) to start algorithm with biggest inclusions


### PR DESCRIPTION
Hi,
I add a plasibility checks in the code, I feel that it is better to add it because when I switch 3D model to 2D frequently, I often forget to change inclusionType, I can still get the model with wrong inclusion type but this will lead clockwise node numbering. And sometimes it takes me lots of time to realize this problem.
Thank you for writing GmshModel, it is quite useful!

Best,
Yulin